### PR TITLE
Manual Arm Drive:  Direction Correction

### DIFF
--- a/src/wr_logic_teleop_arm/nodes/bad_arm_driver.py
+++ b/src/wr_logic_teleop_arm/nodes/bad_arm_driver.py
@@ -82,9 +82,9 @@ def main():
                 if bumper_l.data:
                     if bumper_r.data:
                         pub_forearm.publish(Int16(0))
-                    pub_forearm.publish(Int16(-16384))
-                elif bumper_r.data:
                     pub_forearm.publish(Int16(16384))
+                elif bumper_r.data:
+                    pub_forearm.publish(Int16(-16384))
                 else:
                     pub_forearm.publish(Int16(0))
             
@@ -93,16 +93,16 @@ def main():
                 wrist_spd_b = 0
                 if pov_x.data > 0:
                     wrist_spd_a = 1
-                    wrist_spd_b = -1
+                    wrist_spd_b = 1
                 elif pov_x.data < 0:
                     wrist_spd_a = -1
-                    wrist_spd_b = 1
+                    wrist_spd_b = -1
                 elif pov_y.data > 0:
                     wrist_spd_a = -1
-                    wrist_spd_b = -1
+                    wrist_spd_b = 1
                 elif pov_y.data < 0:
                     wrist_spd_a = 1
-                    wrist_spd_b = 1
+                    wrist_spd_b = -1
                 pub_wrist_a.publish(Int16(24576 * wrist_spd_a))
                 pub_wrist_b.publish(Int16(-24576 * wrist_spd_b))
 

--- a/src/wr_logic_teleop_arm/nodes/bad_arm_driver.py
+++ b/src/wr_logic_teleop_arm/nodes/bad_arm_driver.py
@@ -98,11 +98,11 @@ def main():
                     wrist_spd_a = -1
                     wrist_spd_b = -1
                 elif pov_y.data > 0:
-                    wrist_spd_a = -1
-                    wrist_spd_b = 1
-                elif pov_y.data < 0:
                     wrist_spd_a = 1
                     wrist_spd_b = -1
+                elif pov_y.data < 0:
+                    wrist_spd_a = -1
+                    wrist_spd_b = 1
                 pub_wrist_a.publish(Int16(24576 * wrist_spd_a))
                 pub_wrist_b.publish(Int16(-24576 * wrist_spd_b))
 


### PR DESCRIPTION
The wiring of the new arm is slightly different from the wiring of the old arm, causing some motors to be reversed.  This PR corrects those motors so that the same control in manual drive mode turns the motor the same way as before the new arm.