### PR TITLE
Drive Deadbands

### DIFF
--- a/src/wr_logic_teleop_ds/launch/std.launch
+++ b/src/wr_logic_teleop_ds/launch/std.launch
@@ -3,11 +3,12 @@
 	<group ns="logic">
     <group ns="drive_system">
       <node name="logic_teleop" pkg="wr_logic_teleop_ds" type="TeleopDriveTrainLogic" machine="wrover">
-				<param name="speed_step1" value="0.25"/>
-				<param name="speed_step2" value="0.5"/>
-				<param name="speed_step3" value="0.75"/>
-				<param name="speed_step4" value="1.0"/>
-			</node>
+	<param name="speed_step1" value="0.25"/>
+	<param name="speed_step2" value="0.5"/>
+	<param name="speed_step3" value="0.75"/>
+	<param name="speed_step4" value="1.0"/>
+        <param name="deadband" value="0.1"/>
+      </node>
     </group>
   </group>
 </launch>

--- a/src/wr_logic_teleop_ds/src/TeleopDriveTrainLogic.cpp
+++ b/src/wr_logic_teleop_ds/src/TeleopDriveTrainLogic.cpp
@@ -16,7 +16,7 @@ float SPEED_RATIO_VALUES[] = {0.25, 0.5, 0.75, 1.0};
 //The camera mast speed value
 float speedCamMast = 0.0;
 // Deadband range, centered at 0
-float deadband = 0.1;
+float deadband = 0.0;
 
 #define Std_Bool std_msgs::Bool::ConstPtr&
 #define Std_Float32 std_msgs::Float32::ConstPtr&
@@ -92,6 +92,9 @@ int main(int argc, char** argv){
 	nh.getParam("speed_step3", SPEED_RATIO_VALUES[2]);
 	nh.getParam("speed_step4", SPEED_RATIO_VALUES[3]);
 	
+	//Get Deadband Level
+	nh.getParam("deadband", deadband);
+
 	//Publisher for output data
 	ros::Publisher driveCommand = n.advertise<wr_drive_msgs::DriveTrainCmd>("/control/drive_system/cmd", 1000);
 	ros::Publisher camCommand = n.advertise<wr_drive_msgs::CamMastCmd>("/control/camera/cam_mast_cmd", 1000);

--- a/src/wr_logic_teleop_ds/src/TeleopDriveTrainLogic.cpp
+++ b/src/wr_logic_teleop_ds/src/TeleopDriveTrainLogic.cpp
@@ -15,6 +15,8 @@ float speedRaw[] = {0.0, 0.0};
 float SPEED_RATIO_VALUES[] = {0.25, 0.5, 0.75, 1.0};
 //The camera mast speed value
 float speedCamMast = 0.0;
+// Deadband range, centered at 0
+float deadband = 0.1;
 
 #define Std_Bool std_msgs::Bool::ConstPtr&
 #define Std_Float32 std_msgs::Float32::ConstPtr&
@@ -129,8 +131,8 @@ int main(int argc, char** argv){
 		
 		//Set the left and right values to be the product of respective raw speeds and speed ratios
 		if(!dog.isMad()){
-			output.left_value = speedRaw[0]*speedRatio[0];
-			output.right_value = speedRaw[1]*speedRatio[1];
+			output.left_value = (abs(speedRaw[0]) < deadband ? 0 : speedRaw[0])*speedRatio[0];
+			output.right_value = (abs(speedRaw[1]) < deadband ? 0 : speedRaw[1])*speedRatio[1];
 		}else{
 			output.left_value = 0;
 			output.right_value = 0;


### PR DESCRIPTION
Joystick drift causes the controllers to read nonzero values when they are not being actively driven.  To reduce the effect of this on the drive system, a deadband was added to the teleop logic to ignore low controller values since they are likely to be drift.  This effectively makes the slowest possible input speed `(deadband)*(lowest_speed_setting)`, but the default values make this minimum 0.025=2.5%, which is too low to drive the motors anyways.